### PR TITLE
Bugfix: maintain dashes and case during scope arithmetic

### DIFF
--- a/lib/prx_auth/version.rb
+++ b/lib/prx_auth/version.rb
@@ -1,3 +1,3 @@
 module PrxAuth
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -70,7 +70,16 @@ describe PrxAuth::ScopeList do
       sl = new_list('one two') - nil
       assert sl.contains?(:one) && sl.contains?(:two)
     end
+
+    it 'maintains dashes and capitalization in the result' do
+      sl = new_list('The-Beginning the-middle the-end') - new_list('the-Middle')
+      assert sl.to_s == 'The-Beginning the-end'
+    end
+
   end
+
+  
+
 
   describe '#+' do
     it 'adds scopes' do

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -78,9 +78,6 @@ describe PrxAuth::ScopeList do
 
   end
 
-  
-
-
   describe '#+' do
     it 'adds scopes' do
       sl = new_list('one') + new_list('two')


### PR DESCRIPTION
Primarily aesthetic, since code that checks for scopes should never be looking at string values directly, but having this work this way would have made some tests I have been writing much easier.