### PR TITLE
Feat/rails session flow

### DIFF
--- a/lib/rack/prx_auth/auth_validator.rb
+++ b/lib/rack/prx_auth/auth_validator.rb
@@ -14,15 +14,15 @@ module Rack
       end
 
       def valid?
-        begin
-          decode_token && !expired? && @certificate.valid?(token)
-        rescue JSON::JWT::InvalidFormat
-          false
-        end
+        valid_token_format? && !expired? && @certificate.valid?(token)
       end
 
       def claims
         @claims ||= decode_token
+      end
+
+      def valid_token_format?
+        decode_token.present?
       end
 
       def decode_token

--- a/lib/rack/prx_auth/auth_validator.rb
+++ b/lib/rack/prx_auth/auth_validator.rb
@@ -35,8 +35,6 @@ module Rack
       end
 
       def expired?
-        return true if claims['iat'].nil? || claims['exp'].nil?
-
         now = Time.now.to_i - 30 # 30 second clock jitter allowance
         if claims['iat'] <= claims['exp']
           now > claims['exp']

--- a/lib/rack/prx_auth/auth_validator.rb
+++ b/lib/rack/prx_auth/auth_validator.rb
@@ -1,0 +1,54 @@
+require 'json/jwt'
+require 'net/http'
+
+module Rack
+  class PrxAuth
+    class AuthValidator
+
+      attr_reader :issuer, :claims, :token
+
+      def initialize(token, certificate, issuer)
+        @token = token
+        @certificate = certificate
+        @issuer = issuer
+      end
+
+      def valid?
+        begin
+          decode_token && !expired? && @certificate.valid?(token)
+        rescue JSON::JWT::InvalidFormat
+          false
+        end
+      end
+
+      def claims
+        @claims ||= decode_token
+      end
+
+      def decode_token
+        return {} if token.nil?
+
+        begin
+          JSON::JWT.decode(token, :skip_verification)
+        rescue JSON::JWT::InvalidFormat
+          {}
+        end
+      end
+
+      def expired?
+        return true if claims['iat'].nil? || claims['exp'].nil?
+
+        now = Time.now.to_i - 30 # 30 second clock jitter allowance
+        if claims['iat'] <= claims['exp']
+          now > claims['exp']
+        else
+          now > (claims['iat'] + claims['exp'])
+        end
+      end
+
+      def token_issuer_matches?
+        claims['iss'] == @issuer
+      end
+    end
+  end
+end

--- a/lib/rack/prx_auth/auth_validator.rb
+++ b/lib/rack/prx_auth/auth_validator.rb
@@ -1,5 +1,4 @@
 require 'json/jwt'
-require 'net/http'
 
 module Rack
   class PrxAuth

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -34,7 +34,7 @@ module Rack
       end
 
       def authorized_account_ids(scope)
-        resources(scope).map(&:to_i)
+        resources(::PrxAuth::Rails.configuration.namespace, scope).map(&:to_i)
       end
 
       private

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -32,7 +32,11 @@ module Rack
       def globally_authorized?(namespace, scope=nil)
         authorized?(::PrxAuth::ResourceMap::WILDCARD_KEY, namespace, scope)
       end
-      
+
+      def authorized_account_ids(scope)
+        resources(scope).map(&:to_i)
+      end
+
       private
 
       def unpack_aur(aur)

--- a/prx_auth.gemspec
+++ b/prx_auth.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rack', '>= 1.5.2'
   spec.add_dependency 'json', '>= 1.8.1'
-  spec.add_dependency 'json-jwt', '~> 1.13.0'
+  spec.add_dependency 'json-jwt', '~> 1.12.0'
 end

--- a/prx_auth.gemspec
+++ b/prx_auth.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rack', '>= 1.5.2'
   spec.add_dependency 'json', '>= 1.8.1'
-  spec.add_dependency 'json-jwt', '~> 1.11.0'
+  spec.add_dependency 'json-jwt', '~> 1.13.0'
 end

--- a/test/rack/prx_auth/auth_validator_test.rb
+++ b/test/rack/prx_auth/auth_validator_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+describe Rack::PrxAuth::AuthValidator do
+  let(:app) { Proc.new {|env| env } }
+  let(:auth_validator) { Rack::PrxAuth::AuthValidator.new(token, certificate, 'id.local.test') }
+
+  let(:token) { 'some.token.foo' }
+
+  let(:iat) { Time.now.to_i }
+  let(:exp) { 3600 }
+  let(:claims) { {'sub'=>3, 'exp'=>exp, 'iat'=>iat, 'token_type'=>'bearer', 'scope'=>nil, 'iss'=>'id.prx.org'} }
+  let(:certificate) { cert = Rack::PrxAuth::Certificate.new }
+
+  describe '#token_issuer_matches' do
+    it 'false if the token is from another issuer' do
+      auth_validator.stub(:claims, claims) do
+        refute auth_validator.token_issuer_matches?
+      end
+    end
+
+    it 'is false if the issuer in the validator does not match' do
+      auth_validator.stub(:issuer, 'id.foo.com') do
+        refute auth_validator.token_issuer_matches?
+      end
+    end
+  end
+
+  describe '#valid?' do
+    it 'is false if token is invalid' do
+      auth_validator.stub(:claims, claims) do
+        refute auth_validator.valid?
+      end
+    end
+
+    it 'is false if the token is nil' do
+      certificate.stub(:valid?, true) do
+        auth_validator.stub(:token, nil) do
+          refute auth_validator.valid?
+        end
+      end
+    end
+  end
+
+  describe '#call' do
+
+    it 'checks if access token has expired' do
+      # TODO
+    end
+  end
+
+  describe '#expired?' do
+
+    def expired?(claims)
+      auth_validator.stub(:claims, claims) do
+        auth_validator.expired?
+      end
+    end
+
+    describe 'with a malformed exp' do
+      let(:iat) { Time.now.to_i }
+      let(:exp) { 3600 }
+
+      it 'is expired if iat + exp are in the past' do
+        claims['iat'] -= 3631
+
+        assert expired?(claims)
+      end
+
+      it 'is not expired if iat + exp are in the future' do
+        claims['iat'] = Time.now.to_i - 3599
+
+        refute expired?(claims)
+      end
+
+      it 'allows a 30s clock jitter' do
+        claims['iat'] = Time.now.to_i - 3629
+
+        refute expired?(claims)
+      end
+    end
+
+    describe 'with a corrected exp' do
+      let(:iat) { Time.now.to_i - 3600 }
+      let(:exp) { Time.now.to_i + 1 }
+
+      it 'is not expired if exp is in the future' do
+        refute expired?(claims)
+      end
+
+      it 'is expired if exp is in the past (with 30s jitter grace)' do
+        claims['exp'] = Time.now.to_i - 31
+        assert expired?(claims)
+        claims['exp'] = Time.now.to_i - 29
+        refute expired?(claims)
+      end
+    end
+  end
+
+  describe '#decode_token' do
+    it 'should return an empty result for a nil token' do
+        auth_validator.stub(:token, nil) do
+          assert auth_validator.decode_token == {}
+        end
+    end
+
+    it 'should return an empty result for an empty token' do
+        auth_validator.stub(:token, '') do
+          assert auth_validator.decode_token == {}
+        end
+    end
+
+    it 'should return an empty result for a malformed token' do
+        auth_validator.stub(:token, token) do
+          assert auth_validator.decode_token == {}
+        end
+    end
+  end
+end

--- a/test/rack/prx_auth/auth_validator_test.rb
+++ b/test/rack/prx_auth/auth_validator_test.rb
@@ -41,13 +41,6 @@ describe Rack::PrxAuth::AuthValidator do
     end
   end
 
-  describe '#call' do
-
-    it 'checks if access token has expired' do
-      # TODO
-    end
-  end
-
   describe '#expired?' do
 
     def expired?(claims)


### PR DESCRIPTION
Related to https://github.com/PRX/internal/issues/635,

This extracts out token validation code to prepare for Rails server-side auth flows.  This validation is shared by the rack app here and the controller in the Rails Engine over in [`prx_auth-rails`](https://github.com/PRX/prx_auth-rails/compare/feat/rails-session-flow).