### PR TITLE
Time to live

### DIFF
--- a/lib/prx_auth/version.rb
+++ b/lib/prx_auth/version.rb
@@ -1,3 +1,3 @@
 module PrxAuth
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/lib/rack/prx_auth/auth_validator.rb
+++ b/lib/rack/prx_auth/auth_validator.rb
@@ -40,9 +40,9 @@ module Rack
 
       def time_to_live
         now = Time.now.to_i
-        if claims['iat'].nil? || claims['exp'].nil?
+        if claims['exp'].nil?
           0
-        elsif claims['iat'] <= claims['exp']
+        elsif claims['iat'].nil? || claims['iat'] <= claims['exp']
           claims['exp'] - now
         else
           # malformed - exp is a num-seconds offset from issued-at-time

--- a/lib/rack/prx_auth/certificate.rb
+++ b/lib/rack/prx_auth/certificate.rb
@@ -11,6 +11,7 @@ module Rack
 
       def initialize(cert_uri = nil)
         @cert_location = cert_uri.nil? ? DEFAULT_CERT_LOC : URI(cert_uri)
+        @certificate = nil
       end
 
       def valid?(token)

--- a/test/rack/prx_auth/auth_validator_test.rb
+++ b/test/rack/prx_auth/auth_validator_test.rb
@@ -9,7 +9,7 @@ describe Rack::PrxAuth::AuthValidator do
   let(:iat) { Time.now.to_i }
   let(:exp) { 3600 }
   let(:claims) { {'sub'=>3, 'exp'=>exp, 'iat'=>iat, 'token_type'=>'bearer', 'scope'=>nil, 'iss'=>'id.prx.org'} }
-  let(:certificate) { cert = Rack::PrxAuth::Certificate.new }
+  let(:certificate) { Rack::PrxAuth::Certificate.new }
 
   describe '#token_issuer_matches' do
     it 'false if the token is from another issuer' do
@@ -85,6 +85,16 @@ describe Rack::PrxAuth::AuthValidator do
         assert expired?(claims)
         claims['exp'] = Time.now.to_i - 29
         refute expired?(claims)
+      end
+    end
+  end
+
+  describe '#time_to_live' do
+    let(:exp) { Time.now.to_i + 999 }
+
+    it 'returns the ttl without any clock jitter correction' do
+      auth_validator.stub(:claims, claims) do
+        assert auth_validator.time_to_live == 999
       end
     end
   end

--- a/test/rack/prx_auth/auth_validator_test.rb
+++ b/test/rack/prx_auth/auth_validator_test.rb
@@ -90,12 +90,32 @@ describe Rack::PrxAuth::AuthValidator do
   end
 
   describe '#time_to_live' do
-    let(:exp) { Time.now.to_i + 999 }
+    def time_to_live(claims)
+      auth_validator.stub(:claims, claims) do
+        auth_validator.time_to_live
+      end
+    end
 
     it 'returns the ttl without any clock jitter correction' do
-      auth_validator.stub(:claims, claims) do
-        assert auth_validator.time_to_live == 999
-      end
+      claims['exp'] = Time.now.to_i + 999
+      assert_equal time_to_live(claims), 999
+    end
+
+    it 'handles missing exp' do
+      claims['exp'] = nil
+      assert_equal time_to_live(claims), 0
+    end
+
+    it 'handles missing iat' do
+      claims['iat'] = nil
+      claims['exp'] = Time.now.to_i + 999
+      assert_equal time_to_live(claims), 999
+    end
+
+    it 'handles malformed exp' do
+      claims['iat'] = Time.now.to_i
+      claims['exp'] = 999
+      assert_equal time_to_live(claims), 999
     end
   end
 


### PR DESCRIPTION
Adds a `time_to_live` method to the `AuthValidator`.  Which returns the actual TTL of the token without considering clock-jitter (as the `expired?` method does).

Also cleans up a few warnings in the codebase.