### PR TITLE
Dedup scope lists

### DIFF
--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -42,7 +42,7 @@ module PrxAuth
 
     def initialize(list)
       @string = list
-      @string.split(SCOPE_SEPARATOR).each do |value|
+      @string.split(SCOPE_SEPARATOR).uniq.each do |value|
         next if value.length < 1
 
         parts = value.split(NAMESPACE_SEPARATOR, 2)
@@ -56,21 +56,21 @@ module PrxAuth
 
     def contains?(namespace, scope=nil)
       entries = if scope.nil?
-                  scope, namespace = namespace, NO_NAMESPACE 
+                  scope, namespace = namespace, NO_NAMESPACE
                   [Entry.new(namespace, symbolize(scope), nil)]
                 else
                   scope = symbolize(scope)
                   namespace = symbolize(namespace)
                   [Entry.new(namespace, scope, nil), Entry.new(NO_NAMESPACE, scope, nil)]
                 end
-      
+
       entries.any? do |possible_match|
         include?(possible_match)
       end
     end
 
     def to_s
-      @string
+      entries.join(SCOPE_SEPARATOR)
     end
 
     def condense
@@ -125,7 +125,7 @@ module PrxAuth
 
     def &(other_list)
       return ScopeList.new('') if other_list.nil?
-      
+
       self - (self - other_list) + (other_list - (other_list - self))
     end
 

--- a/lib/prx_auth/version.rb
+++ b/lib/prx_auth/version.rb
@@ -1,3 +1,3 @@
 module PrxAuth
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -12,7 +12,7 @@ describe PrxAuth::ScopeList do
   it 'looks up successfully for a given scope' do
     assert list.contains?('write')
   end
-  
+
   it 'scans for symbols' do
     assert list.contains?(:read)
   end
@@ -27,7 +27,7 @@ describe PrxAuth::ScopeList do
 
   describe 'with namespace' do
     let (:scopes) { 'ns1:hello ns2:goodbye aloha 1:23' }
-    
+
     it 'works for namespaced lookups' do
       assert list.contains?(:ns1, :hello)
     end
@@ -76,6 +76,11 @@ describe PrxAuth::ScopeList do
       assert sl.to_s == 'The-Beginning the-end'
     end
 
+    it 'dedups and condenses' do
+      sl = new_list('one ns1:two ns2:two one three three') - new_list('ns1:two three')
+      assert_equal sl.length, 2
+      assert_equal sl.to_s, 'one ns2:two'
+    end
   end
 
   describe '#+' do
@@ -84,6 +89,12 @@ describe PrxAuth::ScopeList do
       assert sl.kind_of? PrxAuth::ScopeList
       assert sl.contains?(:one)
       assert sl.contains?(:two)
+    end
+
+    it 'dedups and condenses' do
+      sl = new_list('one ns1:one two') + new_list('two three') + new_list('two')
+      assert_equal sl.length, 3
+      assert_equal sl.to_s, 'one two three'
     end
 
     it 'accepts nil' do


### PR DESCRIPTION
Was seeing a bunch of duplicate scopes in my ID token.  Turns out, during scope addition/intersection we weren't de-duping them.  This interferes with our ability to condense the JWT aurs.

This takes my prod auth token size (with delegations I'm in ~200 accounts) from 3524 characters to 2731.

![image](https://user-images.githubusercontent.com/1410587/145842777-5824b87f-12c9-4845-b8dd-9a03411b809f.png)
