### PR TITLE
Except resources

### DIFF
--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -43,6 +43,15 @@ module PrxAuth
       super(key.to_s, value)
     end
 
+    def except!(*keys)
+      keys.each { |key| delete(key.to_s) }
+      self
+    end
+
+    def except(*keys)
+      dup.except!(*keys)
+    end
+
     def condense
       condensed_wildcard = @wildcard.condense
       condensed_map = map do |resource, list|

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -52,6 +52,10 @@ module PrxAuth
       dup.except!(*keys)
     end
 
+    def empty?
+      @wildcard.empty? && (super || values.all?(&:empty?))
+    end
+
     def condense
       condensed_wildcard = @wildcard.condense
       condensed_map = map do |resource, list|

--- a/lib/prx_auth/version.rb
+++ b/lib/prx_auth/version.rb
@@ -1,3 +1,3 @@
 module PrxAuth
-  VERSION = "1.7.2"
+  VERSION = "1.8.0"
 end

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -46,6 +46,10 @@ module Rack
         dup.except!(*resources)
       end
 
+      def empty_resources?
+        @authorized_resources.empty?
+      end
+
       private
 
       def unpack_aur(aur)

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -37,6 +37,15 @@ module Rack
         resources(::PrxAuth::Rails.configuration.namespace, scope).map(&:to_i)
       end
 
+      def except!(*resources)
+        @authorized_resources = @authorized_resources.except(*resources)
+        self
+      end
+
+      def except(*resources)
+        dup.except!(*resources)
+      end
+
       private
 
       def unpack_aur(aur)

--- a/prx_auth.gemspec
+++ b/prx_auth.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls", "~> 0"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-minitest"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "standard"
 
   spec.add_dependency "rack", ">= 1.5.2"

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -181,4 +181,17 @@ describe PrxAuth::ResourceMap do
       refute_nil map["789"]
     end
   end
+
+  describe "#except" do
+    it "removes keys" do
+      map2 = map.except(123)
+
+      assert_equal ["123", "456"], map.keys
+      assert_equal ["456"], map2.keys
+
+      # the ! version modifies the map
+      map2.except!("456")
+      assert_equal [], map2.keys
+    end
+  end
 end

--- a/test/rack/prx_auth/token_data_test.rb
+++ b/test/rack/prx_auth/token_data_test.rb
@@ -97,5 +97,24 @@ describe Rack::PrxAuth::TokenData do
         end
       end
     end
+
+    describe "#except" do
+      let(:token) { Rack::PrxAuth::TokenData.new("aur" => aur) }
+      let(:aur) { {"123" => "admin ns1:namespaced", "456" => "member"} }
+
+      it "removes resources from the aur" do
+        token2 = token.except(123)
+
+        assert token.authorized?(123, "admin")
+        assert token.authorized?(456, "member")
+
+        refute token2.authorized?(123, "admin")
+        assert token2.authorized?(456, "member")
+
+        # the ! version modifies the token
+        token2.except!(456)
+        refute token2.authorized?(456, "member")
+      end
+    end
   end
 end

--- a/test/rack/prx_auth/token_data_test.rb
+++ b/test/rack/prx_auth/token_data_test.rb
@@ -116,5 +116,23 @@ describe Rack::PrxAuth::TokenData do
         refute token2.authorized?(456, "member")
       end
     end
+
+    describe "#empty_resources?" do
+      it "checks if the user has access to any resources" do
+        token = Rack::PrxAuth::TokenData.new("aur" => {"123" => "anything"})
+        refute token.empty_resources?
+        assert token.except("123").empty_resources?
+      end
+
+      it "checks for empty scopes" do
+        token = Rack::PrxAuth::TokenData.new("aur" => {"123" => ""})
+        assert token.empty_resources?
+      end
+
+      it "is not empty with wildcard auth" do
+        token = Rack::PrxAuth::TokenData.new("aur" => {"*" => "anything"})
+        refute token.empty_resources?
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ Coveralls.wear!
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "prx_auth"
 require "rack/prx_auth"
+require "pry"
+require "pry-byebug"
 
 require "minitest/autorun"
 require "minitest/spec"


### PR DESCRIPTION
Adds `except` / `except!` methods to TokenData and ResourceMap.  Used to remove resources from a token entirely.