### PR TITLE
Wildcard global scopes

### DIFF
--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -121,7 +121,7 @@ module PrxAuth
     end
 
     def as_json(opts = {})
-      super(opts).merge((@wildcard.length > 0) ? {WILDCARD_KEY => @wildcard}.as_json(opts) : {})
+      super.merge((@wildcard.length > 0) ? {WILDCARD_KEY => @wildcard}.as_json(opts) : {})
     end
 
     def resources(namespace = nil, scope = nil)

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -113,8 +113,8 @@ module PrxAuth
         end
       end
 
-      if @wildcard.length > 0
-        result[WILDCARD_KEY] = @wildcard - (@wildcard - other_wildcard)
+      if @wildcard.length > 0 || other_wildcard.length > 0
+        result[WILDCARD_KEY] = @wildcard & other_wildcard
       end
 
       ResourceMap.new(result).condense

--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -36,7 +36,7 @@ module PrxAuth
       case list
       when PrxAuth::ScopeList then list
       when Array then super(list.join(" "))
-      else super(list)
+      else super
       end
     end
 

--- a/lib/prx_auth/version.rb
+++ b/lib/prx_auth/version.rb
@@ -1,3 +1,3 @@
 module PrxAuth
-  VERSION = "1.8.0"
+  VERSION = "1.8.1"
 end

--- a/prx_auth.gemspec
+++ b/prx_auth.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-minitest"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "m"
 
   spec.add_dependency "rack", ">= 1.5.2"
   spec.add_dependency "json", ">= 1.8.1"

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -153,6 +153,11 @@ describe PrxAuth::ResourceMap do
       assert !map.contains?("one", :four) && !map.contains?("two", :four)
       assert map.contains?("*", :wild)
     end
+
+    it "works with global scoped wildcards" do
+      map = new_map("*" => "something") & new_map("*" => "ns1:something")
+      assert map.contains?("*", "ns1", :something)
+    end
   end
 
   describe "#as_json" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,6 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "prx_auth"
 require "rack/prx_auth"
 require "pry"
-require "pry-byebug"
 
 require "minitest/autorun"
 require "minitest/spec"


### PR DESCRIPTION
Hit an issue in ID, when requesting a wildcard token for just `feeder:*` scopes.

The ResourceMap `&` operator was dropping some scopes:

```ruby
m1 = PrxAuth::ResourceMap.new("*" => "read-private feeder:read-private")
m2 = PrxAuth::ResourceMap.new("*" => "feeder:read-private")

# before, it was dropping the global read-private entirely!
(m1 & m2).as_json
{}

# after this PR, it correctly intersects them
(m1 & m2).as_json
{"*" => "feeder:read-private"}
```