### PR TITLE
Retry cert requests

### DIFF
--- a/lib/prx_auth/version.rb
+++ b/lib/prx_auth/version.rb
@@ -1,3 +1,3 @@
 module PrxAuth
-  VERSION = "1.8.2"
+  VERSION = "1.8.3"
 end

--- a/lib/rack/prx_auth/certificate.rb
+++ b/lib/rack/prx_auth/certificate.rb
@@ -42,8 +42,20 @@ module Rack
         OpenSSL::X509::Certificate.new(cert_string)
       end
 
-      def fetch_http
-        Net::HTTP.get(cert_location)
+      def fetch_http(retries = 2)
+        host = cert_location.host
+        port = cert_location.port
+        path = cert_location.path
+        ssl = cert_location.scheme == "https"
+        res = Net::HTTP.start(host, port, use_ssl: ssl) { |http| http.request_get(path) }
+
+        if res.is_a?(Net::HTTPSuccess)
+          res.body
+        elsif res.code.to_i >= 500 && retries > 0
+          fetch_http(retries - 1)
+        else
+          raise "Got #{res.code} from #{cert_location}"
+        end
       end
 
       def needs_refresh?

--- a/lib/rack/prx_auth/certificate.rb
+++ b/lib/rack/prx_auth/certificate.rb
@@ -42,7 +42,7 @@ module Rack
         OpenSSL::X509::Certificate.new(cert_string)
       end
 
-      def fetch_http(retries = 2)
+      def fetch_http(retries = 2, sleep_seconds = 0.5)
         host = cert_location.host
         port = cert_location.port
         path = cert_location.path
@@ -52,7 +52,8 @@ module Rack
         if res.is_a?(Net::HTTPSuccess)
           res.body
         elsif res.code.to_i >= 500 && retries > 0
-          fetch_http(retries - 1)
+          sleep sleep_seconds
+          fetch_http(retries - 1, sleep_seconds)
         else
           raise "Got #{res.code} from #{cert_location}"
         end

--- a/lib/rack/prx_auth/certificate.rb
+++ b/lib/rack/prx_auth/certificate.rb
@@ -36,10 +36,14 @@ module Rack
       end
 
       def fetch
-        certs = JSON.parse(Net::HTTP.get(cert_location))
+        certs = JSON.parse(fetch_http)
         cert_string = certs["certificates"].values[0]
         @refresh_at = Time.now.to_i + EXPIRES_IN
         OpenSSL::X509::Certificate.new(cert_string)
+      end
+
+      def fetch_http
+        Net::HTTP.get(cert_location)
       end
 
       def needs_refresh?

--- a/prx_auth.gemspec
+++ b/prx_auth.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "m"
+  spec.add_development_dependency "webmock"
 
   spec.add_dependency "rack", ">= 1.5.2"
   spec.add_dependency "json", ">= 1.8.1"

--- a/test/rack/prx_auth/certificate_test.rb
+++ b/test/rack/prx_auth/certificate_test.rb
@@ -93,7 +93,7 @@ describe Rack::PrxAuth::Certificate do
         .to_return(status: 504)
         .to_return(status: 200, body: TEST_CERT_JSON)
 
-      assert_instance_of OpenSSL::X509::Certificate, certificate.send(:fetch)
+      assert_equal TEST_CERT_JSON, certificate.send(:fetch_http, 2, 0)
     end
 
     it "raises other errors" do
@@ -103,14 +103,14 @@ describe Rack::PrxAuth::Certificate do
         .to_return(status: 503)
         .to_return(status: 504)
 
-      err = assert_raises(RuntimeError) { certificate.send(:fetch) }
+      err = assert_raises(RuntimeError) { certificate.send(:fetch_http, 2, 0) }
       assert_equal "Got 503 from #{cert_uri}", err.message
     end
 
     it "runs out of retries" do
       stub_request(:get, cert_uri).to_return(status: 502).to_return(status: 401)
 
-      err = assert_raises(RuntimeError) { certificate.send(:fetch) }
+      err = assert_raises(RuntimeError) { certificate.send(:fetch_http, 2, 0) }
       assert_equal "Got 401 from #{cert_uri}", err.message
     end
   end

--- a/test/rack/prx_auth/certificate_test.rb
+++ b/test/rack/prx_auth/certificate_test.rb
@@ -86,6 +86,33 @@ describe Rack::PrxAuth::Certificate do
         assert !certificate.send(:needs_refresh?)
       end
     end
+
+    it "retries 5XX errors" do
+      stub_request(:get, cert_uri)
+        .to_return(status: 502)
+        .to_return(status: 504)
+        .to_return(status: 200, body: TEST_CERT_JSON)
+
+      assert_instance_of OpenSSL::X509::Certificate, certificate.send(:fetch)
+    end
+
+    it "raises other errors" do
+      stub_request(:get, cert_uri)
+        .to_return(status: 501)
+        .to_return(status: 502)
+        .to_return(status: 503)
+        .to_return(status: 504)
+
+      err = assert_raises(RuntimeError) { certificate.send(:fetch) }
+      assert_equal "Got 503 from #{cert_uri}", err.message
+    end
+
+    it "runs out of retries" do
+      stub_request(:get, cert_uri).to_return(status: 502).to_return(status: 401)
+
+      err = assert_raises(RuntimeError) { certificate.send(:fetch) }
+      assert_equal "Got 401 from #{cert_uri}", err.message
+    end
   end
 
   describe "#expired?" do

--- a/test/rack/prx_auth/certificate_test.rb
+++ b/test/rack/prx_auth/certificate_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 describe Rack::PrxAuth::Certificate do
-  let(:subject) { Rack::PrxAuth::Certificate.new }
+  let(:cert_uri) { "http://example.com/certs" }
+  let(:subject) { Rack::PrxAuth::Certificate.new(cert_uri) }
   let(:certificate) { subject }
 
   describe "#initialize" do
@@ -11,7 +12,8 @@ describe Rack::PrxAuth::Certificate do
     end
 
     it "defaults to DEFAULT_CERT_LOC" do
-      assert certificate.cert_location == Rack::PrxAuth::Certificate::DEFAULT_CERT_LOC
+      cert = Rack::PrxAuth::Certificate.new
+      assert cert.cert_location == Rack::PrxAuth::Certificate::DEFAULT_CERT_LOC
     end
   end
 
@@ -66,22 +68,22 @@ describe Rack::PrxAuth::Certificate do
   end
 
   describe "#fetch" do
+    let(:fake_json) { "{\"certificates\":{\"asdf\":\"the-cert-content\"}}" }
+
     it "pulls from `#cert_location`" do
-      Net::HTTP.stub(:get, ->(x) { "{\"certificates\":{\"asdf\":\"#{x}\"}}" }) do
-        OpenSSL::X509::Certificate.stub(:new, ->(x) { x }) do
-          certificate.stub(:cert_location, "a://fake.url/here") do
-            assert certificate.send(:fetch) == "a://fake.url/here"
-          end
-        end
+      stub_request(:get, cert_uri).to_return(body: fake_json)
+
+      OpenSSL::X509::Certificate.stub(:new, ->(x) { x }) do
+        assert_equal "the-cert-content", certificate.send(:fetch)
       end
     end
 
     it "sets the expiration value" do
-      Net::HTTP.stub(:get, ->(x) { "{\"certificates\":{\"asdf\":\"#{x}\"}}" }) do
-        OpenSSL::X509::Certificate.stub(:new, ->(_) { Struct.new(:not_after).new(Time.now + 10000) }) do
-          certificate.send :certificate
-          assert !certificate.send(:needs_refresh?)
-        end
+      stub_request(:get, cert_uri).to_return(body: fake_json)
+
+      OpenSSL::X509::Certificate.stub(:new, ->(_) { Struct.new(:not_after).new(Time.now + 10000) }) do
+        certificate.send :certificate
+        assert !certificate.send(:needs_refresh?)
       end
     end
   end

--- a/test/rack/prx_auth_test.rb
+++ b/test/rack/prx_auth_test.rb
@@ -60,6 +60,8 @@ describe Rack::PrxAuth do
     it "attaches claims to request params if verification passes" do
       auth_validator = prxauth.build_auth_validator("sometoken")
 
+      stub_request(:get, Rack::PrxAuth::Certificate::DEFAULT_CERT_LOC).to_return(body: TEST_CERT_JSON)
+
       JSON::JWT.stub(:decode, claims) do
         prxauth.stub(:build_auth_validator, auth_validator) do
           prxauth.call(env)["prx.auth"].tap do |token|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,7 @@ require "pry"
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/pride"
+require "webmock/minitest"
+
+TEST_CERT = "-----BEGIN CERTIFICATE-----\nMIIBGjCBwgIJALc+y9yEBugLMAoGCCqGSM49BAMCMBYxFDASBgNVBAMMC2lkLnBy\neC50ZXN0MB4XDTIyMDYwMzE0MjI0OVoXDTIzMDYwMzE0MjI0OVowFjEUMBIGA1UE\nAwwLaWQucHJ4LnRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQP8/BrEA/7\nHttUpOs0oxWNOtcUH2+0h2Oo/eXNyqs7CRScqmWWShKTzhiBlD8UNYZ3o4+kljl1\nazuLnv1Wxg7PMAoGCCqGSM49BAMCA0cAMEQCICXFwNxJQ9OLzyjN9EJnKQIP+2Jz\nfKWPJ1KyASkFDugyAiAxyfe3vR/XaSJOlJf8MjA5/0feEhiJcSszIrtHFweWLQ==\n-----END CERTIFICATE-----\n"
+TEST_CERT_JSON = JSON.generate({certificates: {abcd1234: TEST_CERT}})


### PR DESCRIPTION
We periodically see 502/504 responses from ID, fetching the cert.

Just add a retry to these.